### PR TITLE
Read multiple ChannelVariables when they exist in AMI Event payload.

### DIFF
--- a/asterisk/ami/event.py
+++ b/asterisk/ami/event.py
@@ -28,6 +28,10 @@ class Event(object):
         for i in range(1, len(lines)):
             try:
                 (key, value) = lines[i].split(': ', 1)
+                if key in ('ChanVariable', 'DestChanVariable'):
+                    key_prefix = 'Dest_' if key == 'DestChanVariable' else ''
+                    key, value = value.split('=',1)
+                    key = key_prefix + key
                 keys[key] = value
             except:
                 pass

--- a/asterisk/ami/event.py
+++ b/asterisk/ami/event.py
@@ -24,15 +24,18 @@ class Event(object):
         if not key.lower() == 'event':
             raise Exception()
         name = value
-        keys = {}
+        keys = {
+            'ChanVariable': {},
+            'DestChanVariable': {}
+        }
         for i in range(1, len(lines)):
             try:
                 (key, value) = lines[i].split(': ', 1)
                 if key in ('ChanVariable', 'DestChanVariable'):
-                    key_prefix = 'Dest_' if key == 'DestChanVariable' else ''
-                    key, value = value.split('=',1)
-                    key = key_prefix + key
-                keys[key] = value
+                    chan_variable_key, value = value.split('=', 1)
+                    keys[key][chan_variable_key] = value
+                else:
+                    keys[key] = value
             except:
                 pass
         return Event(name, keys)

--- a/tests/unit/test_event_listener.py
+++ b/tests/unit/test_event_listener.py
@@ -123,3 +123,31 @@ class EventListenerTest(unittest.TestCase):
         self.assertIsNone(event_listener(event=self.build_some_event(Value1='null')))
         self.assertTrue(event_listener(event=self.build_some_event(Value1='teste')))
         self.assertTrue(event_listener(event=self.build_some_event(Value1='__a__')))
+
+
+class MultipleChannelVariablesTestCase(unittest.TestCase):
+
+    def test_multiple_channel_variables(self):
+
+        VAR1 = 'VAR1'
+        VAR2 = 'VAR2'
+        DEST_VAR1 = 'DEST_VAR1'
+        DEST_VAR2 = 'DEST_VAR2'
+
+        ami_data = '\n'.join([
+            "Event: AgentCalled",
+            "ChanVariable: VAR1=%s" % VAR1,
+            "ChanVariable: VAR2=%s" % VAR2,
+            "DestChanVariable: VAR1=%s" % DEST_VAR1,
+            "DestChanVariable: VAR2=%s" % DEST_VAR2,
+        ])
+
+        event = ami.Event('DummyEvent', {})
+        data = event.read(ami_data).keys
+
+        self.assertTrue(data['VAR1'], VAR1)
+        self.assertTrue(data['VAR2'], VAR2)
+        self.assertTrue(data['Dest_VAR1'], DEST_VAR1)
+        self.assertTrue(data['Dest_VAR2'], DEST_VAR2)
+
+

--- a/tests/unit/test_event_listener.py
+++ b/tests/unit/test_event_listener.py
@@ -127,27 +127,44 @@ class EventListenerTest(unittest.TestCase):
 
 class MultipleChannelVariablesTestCase(unittest.TestCase):
 
-    def test_multiple_channel_variables(self):
+    def test_event_with_multiple_channel_variables(self):
 
-        VAR1 = 'VAR1'
-        VAR2 = 'VAR2'
-        DEST_VAR1 = 'DEST_VAR1'
-        DEST_VAR2 = 'DEST_VAR2'
+        channel_variable = {
+            'VAR1': 'VAR1',
+            'VAR2': 'VAR2'
+        }
+
+        dest_channel_vasiable = {
+            'VAR1': 'D_VAR1',
+            'VAR2': 'D_VAR2'
+        }
+
 
         ami_data = '\n'.join([
             "Event: AgentCalled",
-            "ChanVariable: VAR1=%s" % VAR1,
-            "ChanVariable: VAR2=%s" % VAR2,
-            "DestChanVariable: VAR1=%s" % DEST_VAR1,
-            "DestChanVariable: VAR2=%s" % DEST_VAR2,
+            "ChanVariable: VAR1=%(VAR1)s" % channel_variable,
+            "ChanVariable: VAR2=%(VAR2)s" % channel_variable,
+            "DestChanVariable: VAR1=%(VAR1)s" % dest_channel_vasiable,
+            "DestChanVariable: VAR2=%(VAR2)s" % dest_channel_vasiable,
         ])
 
         event = ami.Event('DummyEvent', {})
         data = event.read(ami_data).keys
 
-        self.assertTrue(data['VAR1'], VAR1)
-        self.assertTrue(data['VAR2'], VAR2)
-        self.assertTrue(data['Dest_VAR1'], DEST_VAR1)
-        self.assertTrue(data['Dest_VAR2'], DEST_VAR2)
+        self.assertDictEqual(data['ChanVariable'], channel_variable)
+        self.assertDictEqual(data['DestChanVariable'], dest_channel_vasiable)
 
+
+    def test_event_without_channel_variables(self):
+
+        ami_data = '\n'.join([
+            "Event: AgentCalled",
+            "SomeVariable: SomeValue"
+        ])
+
+        event = ami.Event('DummyEvent', {})
+        data = event.read(ami_data).keys
+
+        self.assertDictEqual(data['ChanVariable'], {})
+        self.assertDictEqual(data['DestChanVariable'], {})
 


### PR DESCRIPTION
Channel variables specific to a channel can be conveyed in each AMI
event related to that channel. When this occurs, each variable is
referenced in a ChanVariable field. The value of a ChanVariable field
will always be of the form key=value, where key is the name of the
channel variable and value is its value.

Events that relate multiple channels will prefix these fields with an
event specific role specifier. For example, a DialBegin or a DialEnd
event will prefix the outbound channel's fields with Dest. So, the
Channel field is the DestChannel field; the Uniqueid field is the
DestUniqueid field, etc.

https://wiki.asterisk.org/wiki/display/AST/AMI+v2+Specification#AMIv2Specification-event_chanvariable
https://wiki.asterisk.org/wiki/display/AST/AMI+v2+Specification#AMIv2Specification-CommonFields