### PR TITLE
Removed status check for 'Follows' since status seems to always be 'Success'

### DIFF
--- a/asterisk/ami/response.py
+++ b/asterisk/ami/response.py
@@ -14,7 +14,7 @@ class Response(object):
             raise Exception()
         status = value
         keys = {}
-        follows = [] if status.lower() == 'follows' else None
+        follows = []
         keys_and_follows = iter(lines[1:])
         for line in keys_and_follows:
             try:


### PR DESCRIPTION
The content of the status variable seems to always be 'Success' (on recent asterisk version, tested with 15.3.0). Therefore, the follows list is not created but none and the response object is missing a lot of keys.

Simple test:

    action = SimpleAction(
        'SIPshowpeer',
        Peer='2000',
    )
    future = client.send_action(action)
    response = future.response
    print(response)

results in:

> Response: Success
> ActionID: 1
> Channeltype: SIP
> ObjectName: 2000
> ChanObjectType: peer
> SecretExist: Y
> RemoteSecretExist: N
> MD5SecretExist: N
> Context: internal
> Language: 
> ToneZone: <Not set>
> AMAflags: Unknown
> CID-CallingPres: Presentation Allowed, Not Screened
> Callgroup: 
> Pickupgroup: 

while it should be:

> Response: Success
> ActionID: 1
> Channeltype: SIP
> ObjectName: 2000
> ChanObjectType: peer
> SecretExist: Y
> RemoteSecretExist: N
> MD5SecretExist: N
> Context: internal
> Language: 
> ToneZone: <Not set>
> AMAflags: Unknown
> CID-CallingPres: Presentation Allowed, Not Screened
> Callgroup: 
> Pickupgroup: 
> Named Callgroup: 
> Named Pickupgroup: 
> MOHSuggest: 
> VoiceMailbox: 
> TransferMode: open
> LastMsgsSent: 0
> Maxforwards: 0
> Call-limit: 0
> Busy-level: 0
> MaxCallBR: 384 kbps
> Dynamic: Y
> Callerid: "" <>
> RegExpire: -1 seconds
> SIP-AuthInsecure: no
> SIP-Forcerport: Y
> SIP-Comedia: Y
> ACL: N
> SIP-CanReinvite: Y
> SIP-DirectMedia: Y
> SIP-PromiscRedir: N
> SIP-UserPhone: N
> SIP-VideoSupport: N
> SIP-TextSupport: N
> SIP-T.38Support: N
> SIP-T.38EC: Unknown
> SIP-T.38MaxDtgrm: 4294967295
> SIP-Sess-Timers: Accept
> SIP-Sess-Refresh: uas
> SIP-Sess-Expires: 1800
> SIP-Sess-Min: 90
> SIP-RTP-Engine: asterisk
> SIP-Encryption: N
> SIP-RTCP-Mux: N
> SIP-DTMFmode: rfc2833
> ToHost: 
> Address-IP: (null)
> Address-Port: 0
> Default-addr-IP: (null)
> Default-addr-port: 0
> Default-Username: 
> Codecs: (g722|alaw)
> Status: Unmonitored
> SIP-Useragent: 
> Reg-Contact: 
> QualifyFreq: 60000 ms
> Parkinglot: 
> SIP-Use-Reason-Header: N
> Description: 