### PR TITLE
Add some transfer ChanVariable to register_parser

### DIFF
--- a/asterisk/ami/event.py
+++ b/asterisk/ami/event.py
@@ -64,7 +64,8 @@ class EventKeyParser(object):
         raise NotImplementedError()
 
 
-@Event.register_parser('ChanVariable', 'DestChanVariable')
+@Event.register_parser('ChanVariable', 'DestChanVariable', 'TargetChanVariable', 'OrigTransfererChanVariable', 
+                       'SecondTransfererChanVariable', 'TransfereeChanVariable', 'TransferTargetChanVariable')
 class KeyValueParser(EventKeyParser):
     def __call__(self, key, value):
         if key not in self.keys:


### PR DESCRIPTION
Fix for transfer (blind and attended) events with custom ChanVariable 

```
Event: BlindTransfer
Privilege: call,all
Timestamp: 1544364292.076837
Result: Success
TransfererChannel: SIP/100-00000002
TransfererChannelState: 6
TransfererChannelStateDesc: Up
TransfererCallerIDNum: 100
TransfererCallerIDName: Roman
TransfererConnectedLineNum: 101
TransfererConnectedLineName: Alex
TransfererLanguage: en
TransfererAccountCode:
TransfererContext: macro-dial-one
TransfererExten: s
TransfererPriority: 1
TransfererUniqueid: 1544364270.4
TransfererLinkedid: 1544364269.3
TransfererChanVariable: CALLFILENAME=internal-100-101-20181209-170430-1544364269.3
TransfererChanVariable: FROM_DID=
TransfererChanVariable: CHANNEL(hangupsource)=
TransfererChanVariable: DIALSTATUS=
TransfereeChannel: SIP/101-00000001
TransfereeChannelState: 6
TransfereeChannelStateDesc: Up
TransfereeCallerIDNum: 101
TransfereeCallerIDName: Alex
TransfereeConnectedLineNum: 100
TransfereeConnectedLineName: Roman
TransfereeLanguage: en
TransfereeAccountCode:
TransfereeContext: macro-dial-one
TransfereeExten: s
TransfereePriority: 58
TransfereeUniqueid: 1544364269.3
TransfereeLinkedid: 1544364269.3
TransfereeChanVariable: CALLFILENAME=internal-100-101-20181209-170430-1544364269.3
TransfereeChanVariable: FROM_DID=
TransfereeChanVariable: CHANNEL(hangupsource)=
TransfereeChanVariable: DIALSTATUS=ANSWER
BridgeUniqueid: 187be691-90a6-44e1-bd94-852ad62e64eb
BridgeType: basic
BridgeTechnology: simple_bridge
BridgeCreator: <unknown>
BridgeName: <unknown>
BridgeNumChannels: 2
BridgeVideoSourceMode: none
IsExternal: Yes
Context: from-internal-xfer
Extension: 104
```
