### PR TITLE
Concurent issue when connection timeout is not defined

### DIFF
--- a/asterisk/ami/response.py
+++ b/asterisk/ami/response.py
@@ -70,9 +70,10 @@ class FutureResponse(object):
             self._lock.release()
 
     def get_response(self):
-        if self._response is not None:
-            return self._response
         self._lock.acquire()
+        if self._response is not None:
+            self._lock.release()
+            return self._response
         self._lock.wait(self._timeout)
         self._lock.release()
         return self._response


### PR DESCRIPTION
Hello,

When the connection timeout is not defined, we observed a blocking situation

So the connection is defined like this:
```python
AMIClient(address='127.0.0.1', timeout=None)
```

In that case, AMI message received from Asterisk is correctly processed by the stack but in the FuturReponse locking system doesn't give an answer `.response`

If  `set_response`is executed before `get_response`, the `self._lock.wait(None)` is bocking forever since `self._lock.notifyAll()` is already executed
```python
    def set_response(self, response):
        try:
            if self._callback is not None:
                self._callback(response)
        except Exception as ex:
            traceback.print_exc()
        finally:
            self._lock.acquire()
            self._response = response
            self._lock.notifyAll()
            self._lock.release()

    def get_response(self):
        if self._response is not None:
            return self._response
        self._lock.acquire()
        self._lock.wait(self._timeout)
        self._lock.release()
        return self._response
```

We can reproduce the issue with the following code:
```python
import time
import threading

t = threading.Condition()
def t1():
   time.sleep(1)
   print('t1 start')
   t.acquire()
   print("t1 aquired")
   t.notifyAll()
   print("t1 notified all")
   t.release()
   print('t1 end')

def t2():
   print('t2 start')
   time.sleep(5)
   t.acquire()
   print('t2 aquired')
   print('t2 sleeping')
   t.wait(None)
   print('t2 end of wait')
   t.release()
   print('t2 end')

i = threading.Thread(target=t1)
j = threading.Thread(target=t2)
i.start()
j.start()
```

```
t2 start
t1 start
t1 aquired
t1 notified all
t1 end
t2 aquired
t2 sleeping
```

I made a small change to avoid this situation