### PR TITLE
AMI response messages can have multiple time the same header

### DIFF
--- a/asterisk/ami/response.py
+++ b/asterisk/ami/response.py
@@ -17,11 +17,17 @@ class Response(object):
         follows = []
         keys_and_follows = iter(lines[1:])
         for line in keys_and_follows:
+            if not line:
+                continue
             try:
                 (key, value) = line.split(':', 1)
                 if not Response.key_regex.match(key):
                     raise key
-                keys[key.strip()] = value.strip()
+                k = key.strip()
+                if k in keys:
+                    keys[k] += f"\n{value.strip()}"
+                else:
+                    keys[k] = value.strip()
             except:
                 follows.append(line)
                 break


### PR DESCRIPTION
In the latest version of Asterisk when we ask commands via the AMI, get a response on the Output headers. However, if we have a muti-line response, we have multiple times the Output header.

If you need more information tell me.