### PR TITLE
Fix Python 3.12 syntax warning

### DIFF
--- a/asterisk/ami/client.py
+++ b/asterisk/ami/client.py
@@ -49,7 +49,7 @@ class AMIClientListener(object):
 
 
 class AMIClient(object):
-    asterisk_start_regex = re.compile('^Asterisk *Call *Manager/(?P<version>([0-9]+\.)*[0-9]+)', re.IGNORECASE)
+    asterisk_start_regex = re.compile(r'^Asterisk *Call *Manager/(?P<version>([0-9]+\.)*[0-9]+)', re.IGNORECASE)
     asterisk_line_regex = re.compile(b'\r\n', re.IGNORECASE | re.MULTILINE)
     asterisk_pack_regex = re.compile(b'\r\n\r\n', re.IGNORECASE | re.MULTILINE)
 

--- a/asterisk/ami/response.py
+++ b/asterisk/ami/response.py
@@ -4,7 +4,7 @@ import threading
 
 class Response(object):
     match_regex = re.compile('^Response: .*', re.IGNORECASE)
-    key_regex = re.compile('^[a-zA-Z0-9_\-]+$')
+    key_regex = re.compile(r'^[a-zA-Z0-9_\-]+$')
 
     @staticmethod
     def read(response):


### PR DESCRIPTION
On Python version 3.12.1, Python issues the following deprecation warnings:
```
python3.12/site-packages/asterisk/ami/client.py:52: SyntaxWarning: invalid escape sequence '\.'
  asterisk_start_regex = re.compile('^Asterisk *Call *Manager/(?P<version>([0-9]+\.)*[0-9]+)', re.IGNORECASE)
python3.12/site-packages/asterisk/ami/response.py:7: SyntaxWarning: invalid escape sequence '\-'
  key_regex = re.compile('^[a-zA-Z0-9_\-]+$')
```
According to the website https://adamj.eu/tech/2022/11/04/why-does-python-deprecationwarning-invalid-escape-sequence/ this is a warning that future Python versions may change to a syntax error. 

I fixed the warnings by changing the affected strings to a raw string.